### PR TITLE
Bump commons-io from 2.6 to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>